### PR TITLE
feat: add mini.nvim support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ A lot of dark themes are only dark in the sense of their backgrounds. For those 
   - [render-markdown.nvim](https://github.com/MeanderingProgrammer/render-markdown.nvim)
   - [oil.nvim](https://github.com/stevearc/oil.nvim)
   - [oil-git.nvim](https://github.com/malewicz1337/oil-git.nvim)
+  - [mini.nvim](https://github.com/nvim-mini/mini.nvim)
 - Comes with added themes for **other applications** (see [extras](https://github.com/jpwol/thorn.nvim/tree/main/extras))!
   - [Ghostty](https://github.com/ghostty-org/ghostty)
   - [Kitty](https://github.com/kovidgoyal/kitty)

--- a/lua/thorn/groups/init.lua
+++ b/lua/thorn/groups/init.lua
@@ -15,6 +15,7 @@ M.plugins = {
   snacks           = true,
   blink            = true,
   oil              = true,
+  mini             = true,
 }
 
 function M.get(name, colors, opts)

--- a/lua/thorn/groups/mini.lua
+++ b/lua/thorn/groups/mini.lua
@@ -1,0 +1,78 @@
+local M = {}
+
+---@param c thorn.Palette
+---@param opts thorn.StyleOpts
+function M.get(c, opts)
+  return {
+    -- mini.clue
+    MiniClueNextKey = { fg = c.green_6 },
+    MiniClueDescGroup = { fg = c.blue },
+    MiniClueDescSingle = { fg = c.fg },
+
+    -- mini.cmdline
+    MiniCmdlinePeekSep = { bg = c.bg_float },
+
+    -- mini.diff
+    MiniDiffSignAdd = { fg = c.git.add },
+    MiniDiffSignChange = { fg = c.git.change },
+    MiniDiffSignDelete = { fg = c.git.delete },
+
+    -- mini.files
+    MiniFilesCursorLine = "PmenuSel",
+    MiniFilesTitleFocused = { fg = c.blue },
+
+    -- mini.icons
+    MiniIconsAzure = { fg = c.blue },
+    MiniIconsBlue = { fg = c.green_2 },
+    MiniIconsCyan = { fg = c.green_6 },
+    MiniIconsGreen = { fg = c.green_4 },
+    MiniIconsGrey = { fg = c.gray },
+    MiniIconsOrange = { fg = c.orange },
+    MiniIconsPurple = { fg = c.green_0 },
+    MiniIconsRed = { fg = c.red },
+    MiniIconsYellow = { fg = c.yellow },
+
+    -- mini.map
+    MiniMapNormal = { fg = c.gray, bg = c.bg_float },
+
+    -- mini.pick
+    MiniPickMatchCurrent = "PmenuSel",
+    MiniPickMatchMarked = { bg = c.diff.add },
+    MiniPickMatchRanges = "PmenuMatch",
+    MiniPickPrompt = { fg = c.blue, bg = c.bg_float },
+    MiniPickPromptPrefix = { fg = c.green_1, bg = c.bg_float },
+
+    -- mini.starter
+    MiniStarterFooter = "Comment",
+    MiniStarterInactive = { fg = c.green_5 },
+    MiniStarterSection = { fg = c.blue },
+    MiniStarterItemPrefix = { fg = c.yellow },
+    MiniStarterQuery = { fg = c.orange },
+
+    -- mini.statusline
+    MiniStatuslineModeNormal = { bg = c.statusbar.fg, fg = c.bg, bold = true },
+    MiniStatuslineModeInsert = { bg = c.orange, fg = c.bg, bold = true },
+    MiniStatuslineModeVisual = { bg = c.blue, fg = c.bg, bold = true },
+    MiniStatuslineModeReplace = { bg = c.red, fg = c.bg, bold = true },
+    MiniStatuslineModeCommand = { bg = c.yellow, fg = c.bg, bold = true },
+    MiniStatuslineModeOther = { bg = c.orange, fg = c.bg, bold = true },
+    MiniStatuslineDevInfo = { bg = c.statusbar.sep, fg = c.statusbar.fg },
+    MiniStatuslineFileInfo = { bg = c.statusbar.sep, fg = c.statusbar.fg },
+    MiniStatuslineFilename = { bg = c.statusbar.bg, fg = c.gray },
+    MiniStatuslineInactive = { bg = c.statusbar.bg, fg = c.gray },
+
+    -- mini.tabline
+    MiniTablineFill = "TabLineFill",
+    MiniTablineCurrent = { fg = c.green_6, bg = c.statusbar.bg, bold = true },
+    MiniTablineVisible = { fg = c.green_6, bg = c.statusbar.bg },
+    MiniTablineHidden = { fg = c.green_5, bg = c.statusbar.bg },
+    MiniTablineModifiedCurrent = { bg = c.green_6, fg = c.statusbar.bg, bold = true },
+    MiniTablineModifiedVisible = { bg = c.green_6, fg = c.statusbar.bg },
+    MiniTablineModifiedHidden = { bg = c.green_5, fg = c.statusbar.bg },
+
+    -- Mini Trailspace
+    MiniTrailspace = { bg = c.red },
+  }
+end
+
+return M


### PR DESCRIPTION
Add support for various 'mini.nvim' modules to enhance the default out-of-the-box experience.

## mini.clue

<img width="809" height="774" alt="image" src="https://github.com/user-attachments/assets/fa9677bf-8d8e-41e6-a6ba-57fefa71fb7a" />

## mini.cmdline

<img width="809" height="774" alt="image" src="https://github.com/user-attachments/assets/9fd35a7a-a780-44b6-a885-a26031ab4fb7" />

## mini.diff

<img width="809" height="774" alt="image" src="https://github.com/user-attachments/assets/06d38720-cf43-4700-94ee-8ee8536728f2" />

## mini.files

<img width="809" height="774" alt="image" src="https://github.com/user-attachments/assets/45fefffa-05d9-4835-a701-6e5c6ab7b5e1" />

## mini.icons

<img width="809" height="774" alt="image" src="https://github.com/user-attachments/assets/ae582b5f-51b1-4f7f-a67d-ef68825509a7" />

## mini.map

<img width="809" height="774" alt="image" src="https://github.com/user-attachments/assets/4aeeac09-f8af-48c1-9dd6-00d5cca8b766" />

## mini.pick

<img width="809" height="774" alt="image" src="https://github.com/user-attachments/assets/462bf89d-dd4d-4b02-a2ef-009819a91dbb" />

## mini.starter

<img width="809" height="774" alt="image" src="https://github.com/user-attachments/assets/5179b9ed-14c1-48e7-9bd5-b7f21c935a98" />

## mini.statusline

Normal:
<img width="809" height="774" alt="image" src="https://github.com/user-attachments/assets/69fc0bae-91d7-48f6-905f-17b4e7fb5f0c" />

Insert:
<img width="809" height="774" alt="image" src="https://github.com/user-attachments/assets/1c33a195-b9bc-41f3-b7ab-03d7a354655c" />

Visual:
<img width="809" height="774" alt="image" src="https://github.com/user-attachments/assets/a7e3a542-af0d-4113-a020-588d456424fd" />

Replace:
<img width="809" height="774" alt="image" src="https://github.com/user-attachments/assets/40d1b31e-fa15-4ef7-8eef-7109b5a586c9" />

Command:
<img width="809" height="774" alt="image" src="https://github.com/user-attachments/assets/7da8c4ac-0eb3-437c-a256-6ea5d471422d" />

## mini.tabline

5 buffers open, 3 hidden, 2 visible, 1 current (bolded):
<img width="809" height="774" alt="image" src="https://github.com/user-attachments/assets/4b2e7b8e-ee17-4715-9f05-7d3f6ef0b4ce" />

Current window with buffer modified:
<img width="809" height="774" alt="image" src="https://github.com/user-attachments/assets/2f0e55ce-6b56-4c3d-a53c-50f38b25da85" />

Other visible window with buffer modified:
<img width="809" height="774" alt="image" src="https://github.com/user-attachments/assets/33f62e93-94f5-4a64-8f0a-e5763c4ab3e4" />

Hidden window with buffer modified:
<img width="809" height="774" alt="image" src="https://github.com/user-attachments/assets/ad32368c-a837-4894-af21-b36eea6c54f2" />

## mini.trailspace

<img width="809" height="774" alt="image" src="https://github.com/user-attachments/assets/f8715063-fb41-4330-bab9-e386b754b7e3" />
