### PR TITLE
style(mini): differentiate current buffer in mini.tabline

### DIFF
--- a/lua/thorn/groups/mini.lua
+++ b/lua/thorn/groups/mini.lua
@@ -63,10 +63,10 @@ function M.get(c, opts)
 
     -- mini.tabline
     MiniTablineFill = "TabLineFill",
-    MiniTablineCurrent = { fg = c.green_6, bg = c.statusbar.bg, bold = true },
+    MiniTablineCurrent = { fg = c.fg, bg = c.statusbar.bg, bold = true },
     MiniTablineVisible = { fg = c.green_6, bg = c.statusbar.bg },
     MiniTablineHidden = { fg = c.green_5, bg = c.statusbar.bg },
-    MiniTablineModifiedCurrent = { bg = c.green_6, fg = c.statusbar.bg, bold = true },
+    MiniTablineModifiedCurrent = { bg = c.fg, fg = c.statusbar.bg, bold = true },
     MiniTablineModifiedVisible = { bg = c.green_6, fg = c.statusbar.bg },
     MiniTablineModifiedHidden = { bg = c.green_5, fg = c.statusbar.bg },
 


### PR DESCRIPTION
Previously, I used bold to distinguish current buffers from other visible buffers, but using the 'fg' color instead seems better aligned with the theme and 'mini.tabline' in other themes.

Five buffers: 2 hidden, 3 visible including the current one, none modified:
<img width="1162" height="942" alt="image" src="https://github.com/user-attachments/assets/08ac9add-fc47-4205-837c-0da4d25f2ae3" />

Five buffers: 2 hidden, 3 visible including the current one, current modified:
<img width="1162" height="942" alt="image" src="https://github.com/user-attachments/assets/029c963e-0f72-47b4-8260-fd325e29d758" />

Five buffers: 2 hidden, 3 visible including the current one, visible modified:
<img width="1162" height="942" alt="image" src="https://github.com/user-attachments/assets/88d12a0b-8b54-4c43-84c5-24e5fbf9010e" />

Five buffers: 2 hidden, 3 visible including the current one, hidden modified:
<img width="1162" height="942" alt="image" src="https://github.com/user-attachments/assets/34e3a62a-230e-43e3-9980-b5a0b2531605" />

